### PR TITLE
fix(core): Allow nodes duplications #21

### DIFF
--- a/nodes/github/github-collector.html
+++ b/nodes/github/github-collector.html
@@ -6,8 +6,7 @@
             username: { value: '' },
             repoName: { value: '' },
             path: { value: '' },
-            token: { value: '' },
-            id: { value: 'github-collector' }
+            token: { value: '' }
         },
         inputs: 1,
         outputs: 1,

--- a/nodes/procede/filter-by-date.html
+++ b/nodes/procede/filter-by-date.html
@@ -6,8 +6,7 @@
             name: { value: '' },
             attribute: { value: '' },
             startDate: { value: '' },
-            endDate: { value: '' },
-            id: { value: 'filterByDate' }
+            endDate: { value: '' }
         },
         inputs: 1,
         outputs: 1,

--- a/nodes/procede/filter-by.html
+++ b/nodes/procede/filter-by.html
@@ -6,8 +6,7 @@
             name: { value: '' },
             valueType: { value: 'Clasification' },
             attribute: { value: '' },
-            value: { value: '' },
-            id: { value: 'filterBy' }
+            value: { value: '' }
         },
         inputs: 1,
         outputs: 1,

--- a/nodes/trello/trello-collector.html
+++ b/nodes/trello/trello-collector.html
@@ -5,8 +5,7 @@
         defaults: {
             boardId: { value: '' },
             key: { value: '' },
-            token: { value: '' },
-            id: { value: 'trello-collector' }
+            token: { value: '' }
         },
         inputs: 1,
         outputs: 1,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@alvarobc2412/status",
-    "version": "1.0.3",
+    "version": "1.0.5",
     "description": "Collection of STATUS project components.",
     "license": "Apache-2.0",
     "keywords": [


### PR DESCRIPTION
# Description
During the making of the demo I realised that using a default identifier you cannot use several of the same nodes in the same mashup, so I removed the default values to generate unique ids.

# Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
