### PR TITLE
feat: added evidences checkbox

### DIFF
--- a/packages/control-flow/nodes/chain-response.html
+++ b/packages/control-flow/nodes/chain-response.html
@@ -7,6 +7,7 @@
             eventAName: { value: ""},
             eventBName: { value: ""},
             negate: { value: false},
+            storeEvidences: { value: false},
             time: { value: 0, validate: RED.validators.number() },
             params: { value: {
                 eventAName: "string",
@@ -58,8 +59,10 @@
         <label for="node-input-time">Time</label>
         <input type="number" id="node-input-time" placeholder="Time">
     </div>
-
-
+    <div class="form-row">
+        <label for="node-input-storeEvidences">Store Evidences</label>
+        <input type="checkbox" id="node-input-storeEvidences">
+    </div>
 </script>
 <script type="text/x-red" data-help-name="chain-response">
     <p>Checks whether Event B has occurred some <code>time</code> after event A.</p>

--- a/packages/control-flow/nodes/chain-response.js
+++ b/packages/control-flow/nodes/chain-response.js
@@ -1,3 +1,5 @@
+const { v4: uuidv4 } = require('uuid');
+
 module.exports = function (RED) {
     function ChainResponseNode(config) {
         RED.nodes.createNode(this, config);
@@ -8,6 +10,7 @@ module.exports = function (RED) {
             let eventBName = msg.req?.body?.eventBName ?? config.eventBName;
             let negate = msg.req?.body?.negate ?? config.negate;
             let time = msg.req?.body?.time ?? config.time;
+            let storeEvidences = config.storeEvidences;
 
             let trace = (msg.payload.trace && msg.payload.trace.event) || msg.payload.event || msg.payload.events || msg.payload || [];
             if (!Array.isArray(trace)) {
@@ -60,20 +63,22 @@ module.exports = function (RED) {
             }
             msg.payload.result = result;
             msg.payload.evidences = Array.isArray(msg.payload.evidences) ? msg.payload.evidences : [];
-            msg.payload.evidences.push({
-                id: uuidv4(),
-                name: "Chain Response",
-                value: { 
-                    eventA: { 
-                        timestamp: eventTimes.eventA, 
-                        value: eventAName
-                    }, eventB: { 
-                        timestamp: eventTimes.eventB, 
-                        value: eventBName
-                    }
-                },
-                result: result,
-            });
+            if(storeEvidences){
+                msg.payload.evidences.push({
+                    id: uuidv4(),
+                    name: "Chain Response",
+                    value: { 
+                        eventA: { 
+                            timestamp: eventTimes.eventA, 
+                            value: eventAName
+                        }, eventB: { 
+                            timestamp: eventTimes.eventB, 
+                            value: eventBName
+                        }
+                    },
+                    result: result,
+                });
+            };
             node.send(msg);
         });
     }

--- a/packages/control-flow/nodes/coexistence.html
+++ b/packages/control-flow/nodes/coexistence.html
@@ -7,6 +7,7 @@
             eventAName: { value: ""},
             eventBName: { value: ""},
             negate: { value: false},
+            storeEvidences: { value: false},
             params: { value: {
                 eventAName: "string",
                 eventBName: "string",
@@ -51,6 +52,10 @@
     <div class="form-row">
         <label for="node-input-negate">Negate</label>
         <input type="checkbox" id="node-input-negate">
+    </div>
+    <div class="form-row">
+        <label for="node-input-storeEvidences">Store Evidences</label>
+        <input type="checkbox" id="node-input-storeEvidences">
     </div>
 </script>
 <script type="text/x-red" data-help-name="coexistence">

--- a/packages/control-flow/nodes/coexistence.js
+++ b/packages/control-flow/nodes/coexistence.js
@@ -9,6 +9,7 @@ module.exports = function (RED) {
             let eventAName = msg.req?.body?.eventAName ?? config.eventAName;
             let eventBName = msg.req?.body?.eventBName ?? config.eventBName;
             let negate = msg.req?.body?.negate ?? config.negate;
+            let storeEvidences = config.storeEvidences;
 
             let trace = (msg.payload.trace && msg.payload.trace.event) || msg.payload.event || msg.payload.events || msg.payload || [];
 
@@ -53,12 +54,14 @@ module.exports = function (RED) {
 
             msg.payload.result = result
             msg.payload.evidences = Array.isArray(msg.payload.evidences) ? msg.payload.evidences : [];
-            msg.payload.evidences.push({
-                id: uuidv4(),
-                name: "Coexistence",
-                value: [eventAName, eventBName],
-                result: result,
-            });
+            if(storeEvidences){
+                msg.payload.evidences.push({
+                    id: uuidv4(),
+                    name: "Coexistence",
+                    value: [eventAName, eventBName],
+                    result: result,
+                });
+            }
             node.send(msg);
         });
     }

--- a/packages/control-flow/nodes/responded-existence.html
+++ b/packages/control-flow/nodes/responded-existence.html
@@ -7,6 +7,7 @@
             eventAName: { value: ""},
             eventBName: { value: ""},
             negate: { value: false},
+            storeEvidences: { value: false},
             params: { value: {
                 eventAName: "string",
                 eventBName: "string",
@@ -51,6 +52,10 @@
     <div class="form-row">
         <label for="node-input-negate">Negate</label>
         <input type="checkbox" id="node-input-negate">
+    </div>
+    <div class="form-row">
+        <label for="node-input-storeEvidences">Store Evidences</label>
+        <input type="checkbox" id="node-input-storeEvidences">
     </div>
 </script>
 

--- a/packages/control-flow/nodes/responded-existence.js
+++ b/packages/control-flow/nodes/responded-existence.js
@@ -9,6 +9,7 @@ module.exports = function (RED) {
             let eventAName = msg.req?.body?.eventAName ?? config.eventAName;
             let eventBName = msg.req?.body?.eventBName ?? config.eventBName;
             let negate = msg.req?.body?.negate ?? config.negate;
+            let storeEvidences = config.storeEvidences;
 
             let trace = (msg.payload.trace && msg.payload.trace.event) || msg.payload.event || msg.payload.events || msg.payload || [];
 
@@ -58,12 +59,14 @@ module.exports = function (RED) {
             }
 
             newMsg.payload.result = result;
-            newMsg.payload.evidences.push({
-                id: uuidv4(),
-                key: `${eventAName}-${eventBName}`,
-                value: [eventTimestamps.eventA, eventTimestamps.eventB],
-                result: result,
-            });
+            if(storeEvidences){
+                newMsg.payload.evidences.push({
+                    id: uuidv4(),
+                    key: `${eventAName}-${eventBName}`,
+                    value: [eventTimestamps.eventA, eventTimestamps.eventB],
+                    result: result,
+                });
+            }
             node.send(newMsg);
         });
     }

--- a/packages/control-flow/nodes/response.html
+++ b/packages/control-flow/nodes/response.html
@@ -7,6 +7,7 @@
             eventAName: { value: ""},
             eventBName: { value: ""},
             negate: { value: false },
+            storeEvidences: { value: false},
             params: { value: {
                 eventAName: "string",
                 eventBName: "string",
@@ -51,6 +52,10 @@
     <div class="form-row">
         <label for="node-input-negate">Negate</label>
         <input type="checkbox" id="node-input-negate">
+    </div>
+    <div class="form-row">
+        <label for="node-input-storeEvidences">Store Evidences</label>
+        <input type="checkbox" id="node-input-storeEvidences">
     </div>
 </script>
 <script type="text/x-red" data-help-name="response">

--- a/packages/control-flow/nodes/response.js
+++ b/packages/control-flow/nodes/response.js
@@ -9,6 +9,7 @@ module.exports = function (RED) {
             let eventAName = msg.req?.body?.eventAName ?? config.eventAName;
             let eventBName = msg.req?.body?.eventBName ?? config.eventBName;
             let negate = msg.req?.body?.negate ?? config.negate;
+            let storeEvidences = config.storeEvidences;
 
             let trace = (msg.payload.trace && msg.payload.trace.event) || msg.payload.event || msg.payload.events || msg.payload || [];
 
@@ -50,12 +51,14 @@ module.exports = function (RED) {
             }
 
             msg.payload.evidences = Array.isArray(msg.payload.evidences) ? msg.payload.evidences : [];
-            msg.payload.evidences.push({
-                id: uuidv4(),
-                name: "Response",
-                value: [eventAName, eventBName],
-                result: result,
-            });
+            if(storeEvidences){
+                msg.payload.evidences.push({
+                    id: uuidv4(),
+                    name: "Response",
+                    value: [eventAName, eventBName],
+                    result: result,
+                });
+            }
             node.send(msg);
         });
     }

--- a/packages/control-flow/package.json
+++ b/packages/control-flow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@statuscompliance/control-flow",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "Collection of STATUS project components that are responsible for performing control-flow checks.",
     "engines": {
         "node": ">=22.0.0",

--- a/packages/logic/flows.json
+++ b/packages/logic/flows.json
@@ -61,6 +61,7 @@
         "z": "a16837866ec75648",
         "g": "79104e95baf23b39",
         "name": "",
+        "storeEvidences": true,
         "x": 630,
         "y": 260,
         "wires": [
@@ -75,6 +76,7 @@
         "z": "a16837866ec75648",
         "g": "79104e95baf23b39",
         "name": "",
+        "storeEvidences": true,
         "x": 610,
         "y": 420,
         "wires": [
@@ -89,6 +91,7 @@
         "z": "a16837866ec75648",
         "g": "79104e95baf23b39",
         "name": "",
+        "storeEvidences": true,
         "x": 620,
         "y": 500,
         "wires": [
@@ -103,6 +106,7 @@
         "z": "a16837866ec75648",
         "g": "79104e95baf23b39",
         "name": "",
+        "storeEvidences": true,
         "x": 630,
         "y": 340,
         "wires": [
@@ -144,7 +148,7 @@
         "once": false,
         "onceDelay": 0.1,
         "topic": "",
-        "payload": "[{\"result\":true},{\"result\":true}]",
+        "payload": "[{\"result\":true,\"evidences\":[{\"example\":true}]},{\"result\":true}]",
         "payloadType": "json",
         "x": 270,
         "y": 260,
@@ -214,8 +218,8 @@
         "once": false,
         "onceDelay": 0.1,
         "topic": "",
-        "payload": "2",
-        "payloadType": "num",
+        "payload": "{\"result\":2,\"evidences\":[{\"example\":true}]}",
+        "payloadType": "json",
         "x": 270,
         "y": 400,
         "wires": [
@@ -232,7 +236,9 @@
         "name": "Second element",
         "props": [
             {
-                "p": "payload"
+                "p": "payload.result",
+                "v": "5",
+                "vt": "num"
             },
             {
                 "p": "position",
@@ -245,8 +251,6 @@
         "once": false,
         "onceDelay": 0.1,
         "topic": "",
-        "payload": "5",
-        "payloadType": "num",
         "x": 280,
         "y": 440,
         "wires": [
@@ -271,7 +275,7 @@
         "once": false,
         "onceDelay": 0.1,
         "topic": "",
-        "payload": "[{\"result\":true},{\"result\":false}]",
+        "payload": "[{\"result\":true,\"evidences\":[{\"example\":true}]},{\"result\":false}]",
         "payloadType": "json",
         "x": 270,
         "y": 340,
@@ -318,7 +322,7 @@
         "once": false,
         "onceDelay": 0.1,
         "topic": "",
-        "payload": "[{\"result\":false },{\"result\":true}]",
+        "payload": "[{\"result\":false,\"evidences\":[{\"example\":true}]},{\"result\":true}]",
         "payloadType": "json",
         "x": 310,
         "y": 500,
@@ -399,7 +403,9 @@
         "name": "True payload",
         "props": [
             {
-                "p": "payload"
+                "p": "payload.result",
+                "v": "true",
+                "vt": "bool"
             }
         ],
         "repeat": "",
@@ -407,8 +413,6 @@
         "once": false,
         "onceDelay": 0.1,
         "topic": "",
-        "payload": "true",
-        "payloadType": "json",
         "x": 270,
         "y": 580,
         "wires": [
@@ -425,7 +429,9 @@
         "name": "False payload",
         "props": [
             {
-                "p": "payload"
+                "p": "payload.result",
+                "v": "false",
+                "vt": "bool"
             }
         ],
         "repeat": "",
@@ -433,8 +439,6 @@
         "once": false,
         "onceDelay": 0.1,
         "topic": "",
-        "payload": "false",
-        "payloadType": "json",
         "x": 270,
         "y": 620,
         "wires": [

--- a/packages/logic/nodes/and.html
+++ b/packages/logic/nodes/and.html
@@ -4,6 +4,7 @@
         color: '#DDAA99',
         defaults: {
             name: { value: "" },
+            storeEvidences: { value: false},
         },
         inputs: 1,
         outputs: 1,
@@ -30,6 +31,10 @@
     <div class="form-row">
         <label for="node-input-name">Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+    <div class="form-row">
+        <label for="node-input-storeEvidences">Store Evidences</label>
+        <input type="checkbox" id="node-input-storeEvidences">
     </div>
 </script>
 <script type="text/x-red" data-help-name="and">

--- a/packages/logic/nodes/and.js
+++ b/packages/logic/nodes/and.js
@@ -10,21 +10,24 @@ module.exports = function (RED) {
 
         node.on("input", function (msg) {
             let newMsg = { ...msg };
+            let storeEvidences = config.storeEvidences;
             newMsg.payload.evidences = Array.isArray(newMsg.payload.evidences) ? newMsg.payload.evidences : [];
             if (typeof newMsg.payload.result === "boolean") {
                 payloads.push(newMsg.payload.result);
-                evidences = [...evidences, ...newMsg.payload.evidences];
+                evidences = evidences.concat(newMsg.payload.evidences);
             }
             if (payloads.length === 2) {
                 let A = payloads[0];
                 let B = payloads[1];
                 let and = A && B;
-                evidences.push({
-                    id: uuidv4(),
-                    key: 'AND operation',
-                    value: [A, B],
-                    result: and,
-                });
+                if(storeEvidences){
+                    evidences.push({
+                        id: uuidv4(),
+                        key: 'AND operation',
+                        value: [A, B],
+                        result: and,
+                    });
+                }
                 newMsg.payload = {
                     ...msg.payload,
                     result: and,

--- a/packages/logic/nodes/implies.html
+++ b/packages/logic/nodes/implies.html
@@ -4,6 +4,7 @@
         color: '#DDAA99',
         defaults: {
             name: { value: "" },
+            storeEvidences: { value: false},
         },
         inputs: 1,
         outputs: 1,
@@ -30,6 +31,10 @@
     <div class="form-row">
         <label for="node-input-name">Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+    <div class="form-row">
+        <label for="node-input-storeEvidences">Store Evidences</label>
+        <input type="checkbox" id="node-input-storeEvidences">
     </div>
 </script>
 <script type="text/x-red" data-help-name="implies">

--- a/packages/logic/nodes/lesser-than.html
+++ b/packages/logic/nodes/lesser-than.html
@@ -4,6 +4,7 @@
         color: '#DDAA99',
         defaults: {
             name: { value: "" },
+            storeEvidences: { value: false},
         },
         inputs: 1,
         outputs: 1,
@@ -30,6 +31,10 @@
     <div class="form-row">
         <label for="node-input-name">Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+    <div class="form-row">
+        <label for="node-input-storeEvidences">Store Evidences</label>
+        <input type="checkbox" id="node-input-storeEvidences">
     </div>
 </script>
 <script type="text/x-red" data-help-name="lesser-than">

--- a/packages/logic/nodes/lesser-than.js
+++ b/packages/logic/nodes/lesser-than.js
@@ -4,40 +4,41 @@ module.exports = function (RED) {
     function LesserNode(config) {
         RED.nodes.createNode(this, config);
         var node = this;
-        let payloads = {};
+        let payloads = [];
         let evidences = [];
 
         node.on("input", function (msg) {
-            payloads[Number(msg.position) - 1] = msg.payload;
-            msg.payload.evidences = Array.isArray(msg.payload.evidences) ? msg.payload.evidences : [];
+            let newMsg = { ...msg };
+            payloads[Number(newMsg.position) - 1] = newMsg.payload;
+            let storeEvidences = config.storeEvidences;
+            newMsg.payload.evidences = Array.isArray(newMsg.payload.evidences) ? newMsg.payload.evidences : [];
             if (Object.keys(payloads).length === 2) {
-                evidences = [...evidences, ...newMsg.payload.evidences];
-                if (
-                    typeof payloads[0] !== "number" ||
-                    typeof payloads[1] !== "number"
-                ) {
-                    msg.payload.result = false;
-                    msg.payload.evidences.push({
+                evidences = newMsg.payload?.evidences ? [...evidences, ...newMsg.payload.evidences] : evidences;
+
+                const [firstPayload, secondPayload] = [payloads[0], payloads[1]];
+                const isValidNumber = (value) => typeof value === "number";
+                const result = isValidNumber(firstPayload?.result) && isValidNumber(secondPayload?.result) && firstPayload?.result < secondPayload?.result;
+
+                if (storeEvidences) {
+                    evidences.push({
                         id: uuidv4(),
                         name: "LESSER_THAN operation",
-                        value: [payloads[0], payloads[1]],
-                        result: false,
+                        value: [firstPayload?.result, secondPayload?.result],
+                        result: result,
                     });
-                    payloads = {};
-                    evidences = [];
-                    node.send(msg);
                 }
-                let result = payloads[0] < payloads[1];
-                msg.payload.result = result;
-                msg.payload.evidences.push({
-                    id: uuidv4(),
-                    name: "LESSER_THAN operation",
-                    value: [payloads[0], payloads[1]],
+
+                newMsg.payload = {
+                    ...msg.payload,
                     result: result,
-                });
-                payloads = {};
+                    evidences: evidences,
+                };
+                payloads = [];
                 evidences = [];
-                node.send(msg);
+                node.send(newMsg);
+            } else {
+                payloads.push(newMsg.payload.result);
+                evidences = newMsg.payload?.evidences ? [...evidences, ...newMsg.payload.evidences] : evidences;
             }
         });
     }

--- a/packages/logic/nodes/or.html
+++ b/packages/logic/nodes/or.html
@@ -4,6 +4,7 @@
         color: '#DDAA99',
         defaults: {
             name: { value: "" },
+            storeEvidences: { value: false}
         },
         inputs: 1,
         outputs: 1,
@@ -30,6 +31,10 @@
     <div class="form-row">
         <label for="node-input-name">Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+    <div class="form-row">
+        <label for="node-input-storeEvidences">Store Evidences</label>
+        <input type="checkbox" id="node-input-storeEvidences">
     </div>
 </script>
 <script type="text/x-red" data-help-name="or">

--- a/packages/logic/nodes/or.js
+++ b/packages/logic/nodes/or.js
@@ -11,20 +11,27 @@ module.exports = function (RED) {
 
         node.on("input", function (msg) {
             let newMsg = { ...msg };
+            let storeEvidences = config.storeEvidences;
             newMsg.payload.evidences = Array.isArray(newMsg.payload.evidences) ? newMsg.payload.evidences : [];
             if (typeof newMsg.payload.result === "boolean") {
                 payloads.push(newMsg.payload.result);
-                evidences = [...evidences, ...newMsg.payload.evidences];
+                evidences = evidences.concat(newMsg.payload.evidences);
             }
             if (payloads.length === 2) {
                 let result = payloads[0] || payloads[1];
-                newMsg.payload.evidences.push({
-                    id: uuidv4(),
-                    key: 'OR operation',
-                    value: [payloads[0], payloads[1]],
+                if(storeEvidences){
+                    evidences.push({
+                        id: uuidv4(),
+                        key: 'OR operation',
+                        value: [payloads[0], payloads[1]],
+                        result: result,
+                    });
+                }
+                newMsg.payload = {
+                    ...msg.payload,
                     result: result,
-                });
-                newMsg.payload.result = result;
+                    evidences: evidences,
+                };
                 payloads = [];
                 evidences = [];
                 node.send(newMsg);

--- a/packages/logic/package.json
+++ b/packages/logic/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@statuscompliance/logic",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "Collection of components of the STATUS project containing logical operators and similar functions.",
     "engines": {
         "node": ">=22.0.0",

--- a/packages/status/nodes/filter-scope.html
+++ b/packages/status/nodes/filter-scope.html
@@ -15,7 +15,7 @@
         },
         oneditprepare: function() {
             var node = this;
-            var eList = $('#node-input-filter-container').css('min-height','120px').css('min-width','450px');
+            var eList = $('#node-input-filter-container').css('min-height','320px').css('min-width','450px');
             
             eList.editableList({
                 addItem: function(container, index, data) {

--- a/packages/status/package.json
+++ b/packages/status/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@statuscompliance/status",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "Collection of STATUS project components useful for integrating node-red with the system.",
     "engines": {
         "node": ">=22.0.0",

--- a/packages/validation/nodes/check-property.html
+++ b/packages/validation/nodes/check-property.html
@@ -6,6 +6,7 @@
             name: { value: "" },
             propertyToCheck: { value: "" },
             expectedValue: { value: "" },
+            storeEvidences: { value: false},
             params: { 
                 value: {
                     propertyToCheck: 'string',
@@ -46,6 +47,10 @@
     <div class="form-row">
         <label for="node-input-expectedValue"><i class="fa fa-key"></i> Value</label>
         <input type="text" id="node-input-expectedValue" placeholder="Value">
+    </div>
+    <div class="form-row">
+        <label for="node-input-storeEvidences">Store Evidences</label>
+        <input type="checkbox" id="node-input-storeEvidences">
     </div>
 </script>
 <script type="text/x-red" data-help-name="check-property">

--- a/packages/validation/nodes/check-property.js
+++ b/packages/validation/nodes/check-property.js
@@ -7,6 +7,7 @@ module.exports = function (RED) {
         node.on("input", function (msg) {
             const propertyToCheck = msg.req?.body?.propertyToCheck ?? config.propertyToCheck;
             const expectedValue = msg.req?.body?.expectedValue ?? config.expectedValue;
+            const storeEvidences = config.storeEvidences;
 
             if (
                 msg.payload &&
@@ -16,7 +17,8 @@ module.exports = function (RED) {
                 let propertyValue = msg.payload[propertyToCheck];
                 let isMatching = propertyValue === expectedValue;
                 msg.payload.result = isMatching;
-                addEvidence(msg, propertyToCheck, propertyValue, isMatching);
+                
+                addEvidence(msg, propertyToCheck, propertyValue, isMatching, storeEvidences);
                 node.send(msg);
 
             } else if (msg.expectedValue && msg.parts && msg.array) {
@@ -26,22 +28,24 @@ module.exports = function (RED) {
                 let isMatching = propertyValue === msg.expectedValue;
 
                 msg.payload.result = isMatching;
-                addEvidence(msg, msg.propertyToCheck, propertyValue, isMatching);
+                addEvidence(msg, msg.propertyToCheck, propertyValue, isMatching, storeEvidences);
                 node.send(msg);
             } else {
                 msg.payload.result = false;
-                addEvidence(msg, propertyToCheck, "Property not found", false);
+                addEvidence(msg, propertyToCheck, "Property not found", false, storeEvidences);
                 node.send(msg);
             }
         });
         
-        function addEvidence(msg, key, value, result) {
-            msg.payload.evidences.push({
-                id: uuidv4(),
-                key,
-                value,
-                result
-            });
+        function addEvidence(msg, key, value, result, storeEvidences) {
+            if(storeEvidences){
+                msg.payload.evidences.push({
+                    id: uuidv4(),
+                    key,
+                    value,
+                    result
+                });
+            }
         }
     }
 

--- a/packages/validation/nodes/exists-pipe.html
+++ b/packages/validation/nodes/exists-pipe.html
@@ -4,6 +4,7 @@
         color: '#DDAA99',
         defaults: {
             count: { value: 0},
+            storeEvidences: { value: false},
             params: { 
                 value: {
                     count: 'number',
@@ -41,6 +42,10 @@
     <div class="form-row">
         <label for="node-input-count"><i class="icon-number"></i> Count</label>
         <input type="number" id="node-input-count" placeholder="Count">
+    </div>
+    <div class="form-row">
+        <label for="node-input-storeEvidences">Store Evidences</label>
+        <input type="checkbox" id="node-input-storeEvidences">
     </div>
 </script>
 <script type="text/x-red" data-help-name="exists-pipe">

--- a/packages/validation/nodes/exists-pipe.js
+++ b/packages/validation/nodes/exists-pipe.js
@@ -8,18 +8,20 @@ module.exports = function (RED) {
         node.on("input", function (msg) {
             let count = msg.req?.body?.count ?? config.count
             let flowData = (msg.payload.trace && msg.payload.trace.event) || msg.payload.event || msg.payload.events || msg.payload; 
+            const storeEvidences = config.storeEvidences;
             msg.payload.result =  Object.keys(flowData).length == count;
             msg.payload.evidences = Array.isArray(msg.payload.evidences) ? msg.payload.evidences : [];
-            msg.payload.evidences.push({
-                id: uuidv4(),
-                name: "Count",
-                value: {
-                    expected: count,
-                    actual: Object.keys(flowData).length,
-                },
-                result: msg.payload.result,
-            });
-
+            if(storeEvidences){
+                msg.payload.evidences.push({
+                    id: uuidv4(),
+                    name: "Count",
+                    value: {
+                        expected: count,
+                        actual: Object.keys(flowData).length,
+                    },
+                    result: msg.payload.result,
+                });
+            }
             node.send(msg);
         });
     }

--- a/packages/validation/nodes/exists-section-in-doc.html
+++ b/packages/validation/nodes/exists-section-in-doc.html
@@ -12,6 +12,7 @@
             docName: { value: "" },
             url: { value: "" },
             githubToken: { value: "" },
+            storeEvidences: { value: false},
             params: {
                 value: {
                     section: 'string',
@@ -79,6 +80,10 @@
     <div class="form-row">
         <label for="node-input-githubToken"><i class="fa fa-key"></i>GitHub Token</label>
         <input type="text" id="node-input-githubToken" placeholder="Token">
+    </div>
+    <div class="form-row">
+        <label for="node-input-storeEvidences">Store Evidences</label>
+        <input type="checkbox" id="node-input-storeEvidences">
     </div>
 </script>
 <script type="text/x-red" data-help-name="exists-section-in-doc">

--- a/packages/validation/nodes/exists-url.html
+++ b/packages/validation/nodes/exists-url.html
@@ -9,6 +9,7 @@
             apiKey: { value: ''},
             trelloToken: { value: ''},
             githubToken: { value: ''},
+            storeEvidences: { value: false},
             params: {
                 value: {
                     urlType: 'string',
@@ -69,6 +70,10 @@
     <div class="form-row">
         <label for="node-input-githubToken"><i class="fa fa-github"></i>GitHub Token</label>
         <input type="text" id="node-input-githubToken" placeholder="Github Token">
+    </div>
+    <div class="form-row">
+        <label for="node-input-storeEvidences">Store Evidences</label>
+        <input type="checkbox" id="node-input-storeEvidences">
     </div>
 </script>
 <script type="text/x-red" data-help-name="exists-url">

--- a/packages/validation/nodes/has-activity.html
+++ b/packages/validation/nodes/has-activity.html
@@ -7,6 +7,7 @@
             conceptName: { value: "" },
             attribute: { value: "" },
             value: { value: "" },
+            storeEvidences: { value: false},
             params: {
                 value: {
                     conceptName: 'string',
@@ -52,6 +53,10 @@
     <div class="form-row">
         <label for="node-input-value"><i class="fa fa-key"></i> Value (In case of dictionary structure)</label>
         <input type="text" id="node-input-value" placeholder="Value">
+    </div>
+    <div class="form-row">
+        <label for="node-input-storeEvidences">Store Evidences</label>
+        <input type="checkbox" id="node-input-storeEvidences">
     </div>
 </script>
 <script type="text/x-red" data-help-name="has-activity">

--- a/packages/validation/nodes/has-activity.js
+++ b/packages/validation/nodes/has-activity.js
@@ -23,7 +23,7 @@ module.exports = function (RED) {
             let conceptName = msg.req?.body?.conceptName ?? config.conceptName;
             let attribute = msg.req?.body?.attribute ?? config.attribute;
             let value = msg.req?.body?.value ?? config.value;
-
+            const storeEvidences = config.storeEvidences;
             let data = (msg.payload.trace && msg.payload.trace.event) || msg.payload.event || msg.payload.events || msg.payload || [];
 
             if (!Array.isArray(data)) {
@@ -44,13 +44,14 @@ module.exports = function (RED) {
 
             msg.payload.result = result.length > 0;
             msg.payload.evidences = Array.isArray(msg.payload.evidences) ? msg.payload.evidences : [];
-            msg.payload.evidences.push({
-                id: uuidv4(),
-                key: conceptName,
-                value: result.map((item) => item.item),
-                result: result.length > 0,
-            });
-
+            if(storeEvidences){
+                msg.payload.evidences.push({
+                    id: uuidv4(),
+                    key: conceptName,
+                    value: result.map((item) => item.item),
+                    result: result.length > 0,
+                });
+            }
             node.send(msg);
         });
     }

--- a/packages/validation/nodes/is-valid-url.html
+++ b/packages/validation/nodes/is-valid-url.html
@@ -5,6 +5,7 @@
         defaults: {
             string: { value: ""},
             property: { value: "" },
+            storeEvidences: { value: false},
             params: { 
                 value: {
                     property: 'string',
@@ -41,6 +42,10 @@
     <div class="form-row">
         <label for="node-input-property"><i class="icon-tag"></i> Property</label>
         <input type="text" id="node-input-property" placeholder="Property">
+    </div>
+    <div class="form-row">
+        <label for="node-input-storeEvidences">Store Evidences</label>
+        <input type="checkbox" id="node-input-storeEvidences">
     </div>
 </script>
 <script type="text/x-red" data-help-name="is-valid-url">

--- a/packages/validation/nodes/is-valid-url.js
+++ b/packages/validation/nodes/is-valid-url.js
@@ -6,7 +6,7 @@ module.exports = function (RED) {
         var node = this;
         node.on("input", function (msg) {
             let property = msg.req?.body?.property ?? config.property;
-
+            const storeEvidences = config.storeEvidences;
             const urlPattern = new RegExp(
                 "^(https?:\\/\\/)?" +
                     "((([a-zA-Z\\d]([a-zA-Z\\d-]*[a-zA-Z\\d])*)\\.)+[a-zA-Z]{2,}|" +
@@ -22,12 +22,14 @@ module.exports = function (RED) {
             }
             msg.payload.result = result
             msg.payload.evidences = Array.isArray(msg.payload.evidences) ? msg.payload.evidences : [];
-            msg.payload.evidences.push({
-                id: uuidv4(),
-                key: "url",
-                value: msg.payload[property],
-                result: result
-            });
+            if(storeEvidences){
+                msg.payload.evidences.push({
+                    id: uuidv4(),
+                    key: "url",
+                    value: msg.payload[property],
+                    result: result
+                });
+            }
             node.send(msg);
         });
     }

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statuscompliance/validation",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Collection of STATUS project components used for compliance checks",
   "engines": {
     "node": ">=22.0.0",


### PR DESCRIPTION
This pull request introduces a new feature to store evidences for various nodes in the control-flow and logic packages. The changes include updates to the HTML and JavaScript files to support this new functionality. Additionally, the version number in the `package.json` file has been incremented.

### Control-flow package changes:

* [`packages/control-flow/nodes/chain-response.html`](diffhunk://#diff-5cc4419a43cd1aa75fbe7476cb8878c20447250d45be727dde54406427990becR10): Added a new field `storeEvidences` with a corresponding checkbox in the HTML form. [[1]](diffhunk://#diff-5cc4419a43cd1aa75fbe7476cb8878c20447250d45be727dde54406427990becR10) [[2]](diffhunk://#diff-5cc4419a43cd1aa75fbe7476cb8878c20447250d45be727dde54406427990becL61-R65)
* [`packages/control-flow/nodes/chain-response.js`](diffhunk://#diff-f6174574cfb135b43dadb951d7b3f5d6b9400eac496f673218e612690a232942R1-R2): Integrated `storeEvidences` into the node's logic and ensured evidences are stored if the option is enabled. [[1]](diffhunk://#diff-f6174574cfb135b43dadb951d7b3f5d6b9400eac496f673218e612690a232942R1-R2) [[2]](diffhunk://#diff-f6174574cfb135b43dadb951d7b3f5d6b9400eac496f673218e612690a232942R13) [[3]](diffhunk://#diff-f6174574cfb135b43dadb951d7b3f5d6b9400eac496f673218e612690a232942R66) [[4]](diffhunk://#diff-f6174574cfb135b43dadb951d7b3f5d6b9400eac496f673218e612690a232942R81)
* Similar changes were made to the `coexistence`, `responded-existence`, and `response` nodes to support the `storeEvidences` feature. [[1]](diffhunk://#diff-45ea623bb077ac229ca53264daedfedabb6ccacc32962471bce2d77f61734fccR10) [[2]](diffhunk://#diff-45ea623bb077ac229ca53264daedfedabb6ccacc32962471bce2d77f61734fccR56-R59) [[3]](diffhunk://#diff-c2bd48e64ce79cbaaee17d34714c541b4217ab799027e9a995a2806f6288e426R12) [[4]](diffhunk://#diff-c2bd48e64ce79cbaaee17d34714c541b4217ab799027e9a995a2806f6288e426R57-R64) [[5]](diffhunk://#diff-79dcdf8b12450608dd364ba6c7161702688b4351a0fc7222a6055d67145679f2R10) [[6]](diffhunk://#diff-79dcdf8b12450608dd364ba6c7161702688b4351a0fc7222a6055d67145679f2R56-R59) [[7]](diffhunk://#diff-8a4798630a0e531c37f3d66a6c9d4eab6ea69290b7f63a51488eb753a553891bR10) [[8]](diffhunk://#diff-8a4798630a0e531c37f3d66a6c9d4eab6ea69290b7f63a51488eb753a553891bR56-R59) [[9]](diffhunk://#diff-b5a2d7a2d4af5d77e12f482cee85ab535af17cc267b91d7733118c9fe9474301R12) [[10]](diffhunk://#diff-b5a2d7a2d4af5d77e12f482cee85ab535af17cc267b91d7733118c9fe9474301R54-R61)

### Logic package changes:

* [`packages/logic/flows.json`](diffhunk://#diff-9c66ab4e07f712c9058369075fcbbcf64a133d5e7179b9301ae85489f8c848eaR64): Updated several flows to include the `storeEvidences` property and adjusted payloads to include evidences. [[1]](diffhunk://#diff-9c66ab4e07f712c9058369075fcbbcf64a133d5e7179b9301ae85489f8c848eaR64) [[2]](diffhunk://#diff-9c66ab4e07f712c9058369075fcbbcf64a133d5e7179b9301ae85489f8c848eaR79) [[3]](diffhunk://#diff-9c66ab4e07f712c9058369075fcbbcf64a133d5e7179b9301ae85489f8c848eaR94) [[4]](diffhunk://#diff-9c66ab4e07f712c9058369075fcbbcf64a133d5e7179b9301ae85489f8c848eaR109) [[5]](diffhunk://#diff-9c66ab4e07f712c9058369075fcbbcf64a133d5e7179b9301ae85489f8c848eaL147-R151) [[6]](diffhunk://#diff-9c66ab4e07f712c9058369075fcbbcf64a133d5e7179b9301ae85489f8c848eaL217-R222) [[7]](diffhunk://#diff-9c66ab4e07f712c9058369075fcbbcf64a133d5e7179b9301ae85489f8c848eaL235-R241) [[8]](diffhunk://#diff-9c66ab4e07f712c9058369075fcbbcf64a133d5e7179b9301ae85489f8c848eaL248-L249) [[9]](diffhunk://#diff-9c66ab4e07f712c9058369075fcbbcf64a133d5e7179b9301ae85489f8c848eaL274-R278) [[10]](diffhunk://#diff-9c66ab4e07f712c9058369075fcbbcf64a133d5e7179b9301ae85489f8c848eaL321-R325) [[11]](diffhunk://#diff-9c66ab4e07f712c9058369075fcbbcf64a133d5e7179b9301ae85489f8c848eaL402-L411) [[12]](diffhunk://#diff-9c66ab4e07f712c9058369075fcbbcf64a133d5e7179b9301ae85489f8c848eaL428-L437)
* [`packages/logic/nodes/and.html`](diffhunk://#diff-a74614e2d5e8a7874f0a5c36f78fc8c0611ea65fc42e619bed1a0e810ec30ab0R7): Added a new field `storeEvidences` with a corresponding checkbox in the HTML form. [[1]](diffhunk://#diff-a74614e2d5e8a7874f0a5c36f78fc8c0611ea65fc42e619bed1a0e810ec30ab0R7) [[2]](diffhunk://#diff-a74614e2d5e8a7874f0a5c36f78fc8c0611ea65fc42e619bed1a0e810ec30ab0R35-R38)
* [`packages/logic/nodes/and.js`](diffhunk://#diff-a667e36d79efc50afa10ec102c43c261db53d3b01e1d7a470439dac959d4dd3dR13-R30): Integrated `storeEvidences` into the node's logic and ensured evidences are stored if the option is enabled.
* Similar changes were made to the `implies` node to support the `storeEvidences` feature.

### Version update:

* [`packages/control-flow/package.json`](diffhunk://#diff-b7c71e748478b0c722c57a17f801aa10e421725580361081dae80f6671a7642fL3-R3): Incremented the version number from `1.1.1` to `1.1.2`.
* `packages/logic/package.json`: Incremented the version number from `1.1.1` to `1.1.2`.
* `packages/status/package.json`: Incremented the version number from `1.2.1` to `1.2.2`.
* `packages/validation/package.json`: Incremented the version number from `1.1.2` to `1.1.3`.